### PR TITLE
Also check that field offsets match.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 pyo3-ffi = { git = "https://github.com/pyo3/pyo3" }
 pyo3-ffi-check-macro = { path = "./macro" }
+memoffset = "0.6.5"
 
 [workspace]
 members = [

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,11 @@ use std::path::PathBuf;
 
 fn main() {
     let config = pyo3_build_config::get();
-    let python_include_dir = config.run_python_script("import sysconfig; print(sysconfig.get_config_var('INCLUDEPY'), end='');").expect("failed to get lib dir");
+    let python_include_dir = config
+        .run_python_script(
+            "import sysconfig; print(sysconfig.get_config_var('INCLUDEPY'), end='');",
+        )
+        .expect("failed to get lib dir");
 
     println!("cargo:rerun-if-changed=wrapper.h");
     dbg!(format!("-I{python_include_dir}"));

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -10,3 +10,4 @@ proc-macro = true
 glob = "0.3"
 quote = "1"
 proc-macro2 = "1"
+scraper = "0.13"

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -1,6 +1,6 @@
-use std::{env, path::PathBuf};
+use std::{env, fs, path::PathBuf};
 
-use proc_macro2::{TokenStream, Span, Ident, TokenTree};
+use proc_macro2::{Ident, Span, TokenStream, TokenTree};
 use quote::quote;
 
 /// Macro which expands to multiple macro calls, one per pyo3-ffi struct.
@@ -11,15 +11,19 @@ pub fn for_all_structs(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 
     let macro_name = match input.next() {
         Some(TokenTree::Ident(i)) => i,
-        _ => return quote!(
-            compile_error!("generated_test!() takes only a single ident as input")
-        ).into()
+        _ => {
+            return quote!(compile_error!(
+                "generated_test!() takes only a single ident as input"
+            ))
+            .into()
+        }
     };
 
     if !input.next().is_none() {
-        return quote!(
-            compile_error!("generated_test!() takes only a single ident as input")
-        ).into();
+        return quote!(compile_error!(
+            "generated_test!() takes only a single ident as input"
+        ))
+        .into();
     }
 
     let doc_dir = get_doc_dir();
@@ -28,28 +32,115 @@ pub fn for_all_structs(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
     let mut output = TokenStream::new();
 
     for entry in glob::glob(&structs_glob).expect("Failed to read glob pattern") {
-        let entry = entry.unwrap().file_name().unwrap().to_string_lossy().into_owned();
-        let struct_name = entry.strip_prefix("struct.").unwrap().strip_suffix(".html").unwrap();
+        let entry = entry
+            .unwrap()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let struct_name = entry
+            .strip_prefix("struct.")
+            .unwrap()
+            .strip_suffix(".html")
+            .unwrap();
         let struct_ident = Ident::new(struct_name, Span::call_site());
         output.extend(quote!(#macro_name!(#struct_ident);));
     }
 
     if output.is_empty() {
-        quote!(
-            compile_error!(
-                concat!(
-                    "No files found at `",
-                    #structs_glob,
-                    "`, try running `cargo doc -p pyo3-ffi` first."
-                )
-            )
-        )
+        quote!(compile_error!(concat!(
+            "No files found at `",
+            #structs_glob,
+            "`, try running `cargo doc -p pyo3-ffi` first."
+        )))
     } else {
         output
-    }.into()
+    }
+    .into()
 }
 
 fn get_doc_dir() -> PathBuf {
     let path = PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    path.parent().unwrap().parent().unwrap().parent().unwrap().parent().unwrap().to_owned()
+    path.parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_owned()
+}
+
+/// Macro which expands to multiple macro calls, one per field in a pyo3-ffi
+/// struct.
+#[proc_macro]
+pub fn for_all_fields(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input: TokenStream = input.into();
+    let mut input = input.into_iter();
+
+    let struct_name = match input.next() {
+        Some(TokenTree::Ident(i)) => i,
+        _ => {
+            return quote!(compile_error!(
+                "generated_test!() takes exactly two ident as input"
+            ))
+            .into()
+        }
+    };
+
+    match input.next() {
+        Some(TokenTree::Punct(punct)) if punct.as_char() == ',' => (),
+        _ => {
+            return quote!(compile_error!(
+                "generated_test!() takes exactly two ident as input"
+            ))
+            .into()
+        }
+    };
+
+    let macro_name = match input.next() {
+        Some(TokenTree::Ident(i)) => i,
+        _ => {
+            return quote!(compile_error!(
+                "generated_test!() takes exactly two ident as input"
+            ))
+            .into()
+        }
+    };
+
+    if !input.next().is_none() {
+        return quote!(compile_error!(
+            "generated_test!() takes exactly two ident as input"
+        ))
+        .into();
+    }
+
+    let doc_dir = get_doc_dir();
+    let struct_file = fs::read_to_string(format!(
+        "{}/doc/pyo3_ffi/struct.{}.html",
+        doc_dir.display(),
+        struct_name
+    ))
+    .unwrap();
+
+    let html = scraper::Html::parse_document(&struct_file);
+    let selector = scraper::Selector::parse("span.structfield").unwrap();
+
+    let mut output = TokenStream::new();
+
+    for el in html.select(&selector) {
+        let id = el
+            .value()
+            .id()
+            .unwrap()
+            .strip_prefix("structfield.")
+            .unwrap();
+
+        let field_ident = Ident::new(id, Span::call_site());
+
+        output.extend(quote!(#macro_name!(#struct_name, #field_ident);));
+    }
+
+    output.into()
 }


### PR DESCRIPTION
This currently fails to compile because of field name mismatches between bindgen and pyo3_ffi

This implementation is also... creative... it involves parsing HTML.