### PR TITLE
use extension-module feature to skip linking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,13 @@ name = "pyo3-ffi-check"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-pyo3-ffi = { git = "https://github.com/pyo3/pyo3" }
 pyo3-ffi-check-macro = { path = "./macro" }
 memoffset = "0.6.5"
+
+[dependencies.pyo3-ffi]
+git = "https://github.com/pyo3/pyo3"
+features = ["extension-module"]  # A lazy way of skipping linking in most cases (as we don't use any runtime symbols)
 
 [workspace]
 members = [

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -13,7 +13,7 @@ pub fn for_all_structs(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
         Some(TokenTree::Ident(i)) => i,
         _ => {
             return quote!(compile_error!(
-                "generated_test!() takes only a single ident as input"
+                "for_all_structs!() takes only a single ident as input"
             ))
             .into()
         }
@@ -21,7 +21,7 @@ pub fn for_all_structs(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 
     if !input.next().is_none() {
         return quote!(compile_error!(
-            "generated_test!() takes only a single ident as input"
+            "for_all_structs!() takes only a single ident as input"
         ))
         .into();
     }
@@ -83,7 +83,7 @@ pub fn for_all_fields(input: proc_macro::TokenStream) -> proc_macro::TokenStream
         Some(TokenTree::Ident(i)) => i,
         _ => {
             return quote!(compile_error!(
-                "generated_test!() takes exactly two ident as input"
+                "for_all_fields!() takes exactly two idents as input"
             ))
             .into()
         }
@@ -93,7 +93,7 @@ pub fn for_all_fields(input: proc_macro::TokenStream) -> proc_macro::TokenStream
         Some(TokenTree::Punct(punct)) if punct.as_char() == ',' => (),
         _ => {
             return quote!(compile_error!(
-                "generated_test!() takes exactly two ident as input"
+                "for_all_fields!() takes exactly two idents as input"
             ))
             .into()
         }
@@ -103,7 +103,7 @@ pub fn for_all_fields(input: proc_macro::TokenStream) -> proc_macro::TokenStream
         Some(TokenTree::Ident(i)) => i,
         _ => {
             return quote!(compile_error!(
-                "generated_test!() takes exactly two ident as input"
+                "for_all_fields!() takes exactly two idents as input"
             ))
             .into()
         }
@@ -111,7 +111,7 @@ pub fn for_all_fields(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 
     if !input.next().is_none() {
         return quote!(compile_error!(
-            "generated_test!() takes exactly two ident as input"
+            "for_all_fields!() takes exactly two idents as input"
         ))
         .into();
     }


### PR DESCRIPTION
Won't work for windows, however it only seemed to be PyPy on Mac which was having link trouble anyway.