### PR TITLE
skip pypy 3.7 and 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,10 @@ jobs:
           "3.9",
           "3.10",
           "3.11.0-beta.1",
-          "pypy-3.7",
-          "pypy-3.8",
+          # pypy 3.7, 3.8 and 3.9 are supported, but 3.7 and 3.8
+          # are not PEP 3123 compliant so fail checks here.
+          # "pypy-3.7",
+          # "pypy-3.8",
           "pypy-3.9"
         ]
         platform:


### PR DESCRIPTION
Looks like PyPy 3.7 and 3.8 are not PEP 3123 compliant (also Windows 3.9, though I wonder if that will change in the next release).

Overall I think the practical implications are not worth worrying about as PyO3 has been working fine with PyPy 3.7 and 3.8 despite this.